### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,16 @@
 Fish like creatures based on pure react-native views and styles.
 (*pure js, pure views, no images*)
 
-####Example:
+#### Example:
 ![alt tag](https://github.com/istarkov/react-native-fish/blob/master/docs/fish_example.gif)
 
-####Todo
+#### Todo
 * add fish tail
 * add not quad flake
 * find how to sync animations
 * add arms, wings, multihead
 
-####How it works
+#### How it works
 * place n views on a "layer" and rotate each
 * ![alt tag](https://github.com/istarkov/react-native-fish/blob/master/docs/1.gif)
 * add "layer" rotation


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
